### PR TITLE
Use whitelisted tag names to avoid rendering invalid content

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -7,11 +7,16 @@ import {
 } from './utils/dom';
 import ImageCard from './cards/image';
 import RENDER_TYPE from './utils/render-type';
-
-const MARKUP_SECTION_TYPE = 1;
-const IMAGE_SECTION_TYPE = 2;
-const LIST_SECTION_TYPE = 3;
-const CARD_SECTION_TYPE = 10;
+import {
+  MARKUP_SECTION_TYPE,
+  IMAGE_SECTION_TYPE,
+  LIST_SECTION_TYPE,
+  CARD_SECTION_TYPE
+} from './utils/section-types';
+import {
+  isValidSectionTagName,
+  isValidMarkerType
+} from './utils/tag-names';
 
 /**
  * runtime HTML renderer
@@ -66,7 +71,10 @@ export default class Renderer {
 
   render() {
     this.sections.forEach((section) => {
-      appendChild(this.root, this.renderSection(section));
+      let rendered = this.renderSection(section);
+      if (rendered) {
+        appendChild(this.root, rendered);
+      }
     });
 
     return { result: this.root.toString(), teardown: () => this.teardown() };
@@ -95,6 +103,9 @@ export default class Renderer {
   }
 
   renderListSection([type, tagName, items]) {
+    if (!isValidSectionTagName(tagName, LIST_SECTION_TYPE)) {
+      return;
+    }
     const element = createElement(tagName);
     items.forEach(li => {
       appendChild(element, this.renderListItem(li));
@@ -172,7 +183,7 @@ export default class Renderer {
     }
 
     if (typeof rendered !== 'string') {
-      throw new Error(`Card "${cardName}" must render ${RENDER_TYPE}, but result was ${typeof rendered}`);
+      throw new Error(`Card "${cardName}" must render ${RENDER_TYPE}, but result was ${typeof rendered}"`);
     }
   }
 
@@ -181,6 +192,9 @@ export default class Renderer {
   }
 
   renderMarkupSection([type, tagName, markers]) {
+    if (!isValidSectionTagName(tagName, MARKUP_SECTION_TYPE)) {
+      return;
+    }
     const element = createElement(tagName);
     this._renderMarkersOnElement(element, markers);
     return element;
@@ -192,19 +206,24 @@ export default class Renderer {
 
     for (let i=0, l=markers.length; i<l; i++) {
       let marker = markers[i];
-      let [openTypes, closeTypes, text] = marker;
+      let [openTypes, closeCount, text] = marker;
 
       for (let j=0, m=openTypes.length; j<m; j++) {
         let markerType = this.markerTypes[openTypes[j]];
-        let openedElement = createElementFromMarkerType(markerType);
-        appendChild(currentElement, openedElement);
-        elements.push(openedElement);
-        currentElement = openedElement;
+        let [tagName] = markerType;
+        if (isValidMarkerType(tagName)) {
+          let openedElement = createElementFromMarkerType(markerType);
+          appendChild(currentElement, openedElement);
+          elements.push(openedElement);
+          currentElement = openedElement;
+        } else {
+          closeCount--;
+        }
       }
 
       appendChild(currentElement, createTextNode(text));
 
-      for (let j=0, m=closeTypes; j<m; j++) {
+      for (let j=0, m=closeCount; j<m; j++) {
         elements.pop();
         currentElement = elements[elements.length - 1];
       }

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -72,3 +72,7 @@ export function setAttribute(element, propName, propValue) {
 export function createDocumentFragment() {
   return createElement('div');
 }
+
+export function normalizeTagName(name) {
+  return name.toLowerCase();
+}

--- a/lib/utils/section-types.js
+++ b/lib/utils/section-types.js
@@ -1,0 +1,4 @@
+export const MARKUP_SECTION_TYPE = 1;
+export const IMAGE_SECTION_TYPE = 2;
+export const LIST_SECTION_TYPE = 3;
+export const CARD_SECTION_TYPE = 10;

--- a/lib/utils/tag-names.js
+++ b/lib/utils/tag-names.js
@@ -1,0 +1,39 @@
+import {
+  MARKUP_SECTION_TYPE,
+  LIST_SECTION_TYPE
+} from './section-types';
+import { normalizeTagName } from './dom';
+
+const MARKUP_SECTION_TAG_NAMES = [
+  'p', 'h1', 'h2', 'h3', 'blockquote', 'pull-quote'
+].map(normalizeTagName);
+
+const LIST_SECTION_TAG_NAMES = [
+  'ul', 'ol'
+].map(normalizeTagName);
+
+const MARKUP_TYPES = [
+  'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's'
+].map(normalizeTagName);
+
+function contains(array, item) {
+  return array.indexOf(item) !== -1;
+}
+
+export function isValidSectionTagName(tagName, sectionType) {
+  tagName = normalizeTagName(tagName);
+
+  switch (sectionType) {
+    case MARKUP_SECTION_TYPE:
+      return contains(MARKUP_SECTION_TAG_NAMES, tagName);
+    case LIST_SECTION_TYPE:
+      return contains(LIST_SECTION_TAG_NAMES, tagName);
+    default:
+      throw new Error(`Cannot validate tagName for unknown section type "${sectionType}"`);
+  }
+}
+
+export function isValidMarkerType(type) {
+  type = normalizeTagName(type);
+  return contains(MARKUP_TYPES, type);
+}

--- a/tests/unit/renderer-test.js
+++ b/tests/unit/renderer-test.js
@@ -1,23 +1,196 @@
 /* global QUnit */
 
-const { test } = QUnit;
-
 import Renderer from 'mobiledoc-html-renderer';
-const MOBILEDOC_VERSION = '0.2.0';
 import ImageCard from 'mobiledoc-html-renderer/cards/image';
+import {
+  MARKUP_SECTION_TYPE,
+  LIST_SECTION_TYPE,
+  CARD_SECTION_TYPE,
+  IMAGE_SECTION_TYPE
+} from 'mobiledoc-html-renderer/utils/section-types';
 
+const { test, module } = QUnit;
+const MOBILEDOC_VERSION = '0.2.0';
 const dataUri = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
 
 let renderer;
-QUnit.module('Unit: Mobiledoc HTML Renderer', {
+module('Unit: Mobiledoc HTML Renderer', {
   beforeEach() {
     renderer = new Renderer();
   }
 });
 
-test('it exists', (assert) => {
-  assert.ok(Renderer, 'class exists');
-  assert.ok(renderer, 'instance exists');
+test('renders an empty mobiledoc', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [], // markers
+      []  // sections
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+
+  assert.ok(rendered, 'renders output');
+  assert.equal(rendered, '<div></div>', 'output is empty');
+});
+
+test('renders a mobiledoc without markups', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [], // markers
+      [   // sections
+        [MARKUP_SECTION_TYPE, 'P', [
+          [[], 0, 'hello world']]
+        ]
+      ]
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered,
+               '<div><p>hello world</p></div>');
+});
+
+test('renders a mobiledoc with simple (no attributes) markup', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [        // markups
+        ['B'],
+      ],
+      [        // sections
+        [MARKUP_SECTION_TYPE, 'P', [
+          [[0], 1, 'hello world']]
+        ]
+      ]
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered, '<div><p><b>hello world</b></p></div>');
+});
+
+test('renders a mobiledoc with complex (has attributes) markup', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [        // markers
+        ['A', ['href', 'http://google.com']],
+      ],
+      [        // sections
+        [MARKUP_SECTION_TYPE, 'P', [
+            [[0], 1, 'hello world']
+        ]]
+      ]
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered, '<div><p><a href="http://google.com">hello world</a></p></div>');
+});
+
+test('renders a mobiledoc with multiple markups in a section', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [        // markers
+        ['B'],
+        ['I']
+      ],
+      [        // sections
+        [MARKUP_SECTION_TYPE, 'P', [
+          [[0], 0, 'hello '], // b
+          [[1], 0, 'brave '], // b+i
+          [[], 1, 'new '], // close i
+          [[], 1, 'world'] // close b
+        ]]
+      ]
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered, '<div><p><b>hello <i>brave new </i>world</b></p></div>');
+});
+
+test('renders a mobiledoc with image section', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],      // markers
+      [        // sections
+        [IMAGE_SECTION_TYPE, dataUri]
+      ]
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered, `<div><img src="${dataUri}"></div>`);
+});
+
+test('renders a mobiledoc with built-in image card', (assert) => {
+  assert.expect(1);
+  let cardName = ImageCard.name;
+  let payload = { src: dataUri };
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],      // markers
+      [        // sections
+        [CARD_SECTION_TYPE, cardName, payload]
+      ]
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+
+  assert.equal(rendered, `<div><div><img src="${dataUri}"></div></div>`);
+});
+
+test('render mobiledoc with list section and list items', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [
+        [LIST_SECTION_TYPE, 'ul', [
+          [[[], 0, 'first item']],
+          [[[], 0, 'second item']]
+        ]]
+      ]
+    ]
+  };
+  const { result: rendered } = renderer.render(mobiledoc);
+
+  assert.equal(rendered,
+               '<div><ul><li>first item</li><li>second item</li></ul></div>');
+});
+
+test('renders a mobiledoc with card section', (assert) => {
+  assert.expect(6);
+
+  let cardName = 'title-card';
+  let expectedPayload = {};
+  let expectedOptions = {};
+  let titleCard = {
+    name: cardName,
+    type: 'html',
+    render: ({env, payload, options}) => {
+      assert.deepEqual(payload, expectedPayload, 'correct payload');
+      assert.deepEqual(options, expectedOptions, 'correct options');
+      assert.equal(env.name, cardName, 'correct name');
+      assert.ok(!env.isInEditor, 'isInEditor correct');
+      assert.ok(!!env.onTeardown, 'has onTeardown hook');
+
+      return 'Howdy friend';
+    }
+  };
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],      // markers
+      [        // sections
+        [CARD_SECTION_TYPE, cardName, expectedPayload]
+      ]
+    ]
+  };
+  renderer = new Renderer({cards: [titleCard], cardOptions: expectedOptions});
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered, '<div><div>Howdy friend</div></div>');
 });
 
 test('throws when given invalid card type', (assert) => {
@@ -42,7 +215,7 @@ test('throws when given card without `render`', (assert) => {
     /Card "bad" must define.*render/);
 });
 
-test('throws if card renders invalid response', (assert) => {
+test('throws if card render returns invalid result', (assert) => {
   let card = {
     name: 'bad',
     type: 'html',
@@ -54,13 +227,126 @@ test('throws if card renders invalid response', (assert) => {
     version: MOBILEDOC_VERSION,
     sections: [
       [], // markers
-      [[10, card.name]]  // sections
+      [[CARD_SECTION_TYPE, card.name]]  // sections
     ]
   };
   renderer = new Renderer({cards: [card]});
   assert.throws(
     () => renderer.render(mobiledoc),
     /Card "bad" must render html/
+  );
+});
+
+test('card may render nothing', (assert) => {
+  let card = {
+    name: 'ok',
+    type: 'html',
+    render() {}
+  };
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [
+        [CARD_SECTION_TYPE, card.name]
+      ]
+    ]
+  };
+
+  renderer = new Renderer({cards:[card]});
+  renderer.render(mobiledoc);
+
+  assert.ok(true, 'No error thrown');
+});
+
+test('rendering nested mobiledocs in cards', (assert) => {
+  let cards = [{
+    name: 'nested-card',
+    type: 'html',
+    render({payload}) {
+      let {result: rendered} = renderer.render(payload.mobiledoc);
+      return rendered;
+    }
+  }];
+
+  let innerMobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [], // markers
+      [   // sections
+        [MARKUP_SECTION_TYPE, 'P', [
+          [[], 0, 'hello world']]
+        ]
+      ]
+    ]
+  };
+
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [], // markers
+      [   // sections
+        [CARD_SECTION_TYPE, 'nested-card', {mobiledoc: innerMobiledoc}]
+      ]
+    ]
+  };
+
+  let renderer = new Renderer({cards});
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered, '<div><div><div><p>hello world</p></div></div></div>');
+});
+
+test('rendering unknown card without unknownCardHandler throws', (assert) => {
+  let cardName = 'missing-card';
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],      // markers
+      [        // sections
+        [CARD_SECTION_TYPE, cardName]
+      ]
+    ]
+  };
+  renderer = new Renderer({cards: [], unknownCardHandler: undefined});
+
+  assert.throws(
+    () => renderer.render(mobiledoc),
+    /Card "missing-card" not found.*no unknownCardHandler/
+  );
+});
+
+test('rendering unknown card uses unknownCardHandler', (assert) => {
+  assert.expect(5);
+
+  let cardName = 'missing-card';
+  let expectedPayload = {};
+  let cardOptions = {};
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],      // markers
+      [        // sections
+        [CARD_SECTION_TYPE, cardName, expectedPayload]
+      ]
+    ]
+  };
+  let unknownCardHandler = ({env, payload, options}) => {
+    assert.equal(env.name, cardName, 'correct name');
+    assert.ok(!env.isInEditor, 'correct isInEditor');
+    assert.ok(!!env.onTeardown, 'onTeardown hook exists');
+
+    assert.deepEqual(payload, expectedPayload, 'correct payload');
+    assert.deepEqual(options, cardOptions, 'correct options');
+  };
+  renderer = new Renderer({cards: [], unknownCardHandler, cardOptions});
+  renderer.render(mobiledoc);
+});
+
+test('throws if given an object of cards', (assert) => {
+  let cards = {};
+  assert.throws(
+    () => { new Renderer({cards}) }, // jshint ignore: line
+    new RegExp('`cards` must be passed as an array')
   );
 });
 
@@ -77,7 +363,7 @@ test('teardown hook calls registered teardown methods', (assert) => {
     version: MOBILEDOC_VERSION,
     sections: [
       [], // markers
-      [[10, card.name]]  // sections
+      [[CARD_SECTION_TYPE, card.name]]  // sections
     ]
   };
   renderer = new Renderer({cards: [card]});
@@ -90,226 +376,7 @@ test('teardown hook calls registered teardown methods', (assert) => {
   assert.ok(didTeardown, 'teardown hook called');
 });
 
-test('renders an empty mobiledoc', (assert) => {
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [], // markers
-      []  // sections
-    ]
-  };
-  let { result: rendered } = renderer.render(mobiledoc);
-
-  assert.ok(rendered, 'renders output');
-  assert.equal(rendered, '<div></div>', 'output is empty');
-});
-
-test('renders a mobiledoc without markers', (assert) => {
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [], // markers
-      [   // sections
-        [1, 'P', [
-          [[], 0, 'hello world']]
-        ]
-      ]
-    ]
-  };
-  let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered,
-               '<div><p>hello world</p></div>');
-});
-
-test('renders a mobiledoc with simple (no attributes) marker', (assert) => {
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [        // markers
-        ['B'],
-      ],
-      [        // sections
-        [1, 'P', [
-          [[0], 1, 'hello world']]
-        ]
-      ]
-    ]
-  };
-  let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered, '<div><p><b>hello world</b></p></div>');
-});
-
-test('renders a mobiledoc with complex (has attributes) marker', (assert) => {
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [        // markers
-        ['A', ['href', 'http://google.com']],
-      ],
-      [        // sections
-        [1, 'P', [
-            [[0], 1, 'hello world']
-        ]]
-      ]
-    ]
-  };
-  let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered, '<div><p><a href="http://google.com">hello world</a></p></div>');
-});
-
-test('renders a mobiledoc with multiple markups in a section', (assert) => {
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [        // markers
-        ['B'],
-        ['I']
-      ],
-      [        // sections
-        [1, 'P', [
-          [[0], 0, 'hello '], // b
-          [[1], 0, 'brave '], // b+i
-          [[], 1, 'new '], // close i
-          [[], 1, 'world'] // close b
-        ]]
-      ]
-    ]
-  };
-  let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered, '<div><p><b>hello <i>brave new </i>world</b></p></div>');
-});
-
-test('renders a mobiledoc with img section', (assert) => {
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [],      // markers
-      [        // sections
-        [2, dataUri]
-      ]
-    ]
-  };
-  let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered, `<div><img src="${dataUri}"></div>`);
-});
-
-test('renders unknown card with unknownCardHandler', (assert) => {
-  assert.expect(5);
-
-  let cardName = 'missing-card';
-  let expectedPayload = {};
-  let cardOptions = {};
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [],      // markers
-      [        // sections
-        [10, cardName, expectedPayload]
-      ]
-    ]
-  };
-  let unknownCardHandler = ({env, payload, options}) => {
-    assert.equal(env.name, cardName, 'correct name');
-    assert.ok(!env.isInEditor, 'correct isInEditor');
-    assert.ok(!!env.onTeardown, 'onTeardown hook exists');
-
-    assert.deepEqual(payload, expectedPayload, 'correct payload');
-    assert.deepEqual(options, cardOptions, 'correct options');
-  };
-  renderer = new Renderer({cards: [], unknownCardHandler, cardOptions});
-  renderer.render(mobiledoc);
-});
-
-test('throws when encountering unknown card and no unknownCardHandler', (assert) => {
-  let cardName = 'missing-card';
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [],      // markers
-      [        // sections
-        [10, cardName]
-      ]
-    ]
-  };
-  renderer = new Renderer({cards: [], unknownCardHandler: undefined});
-
-  assert.throws(
-    () => renderer.render(mobiledoc),
-    /Card "missing-card" not found.*no unknownCardHandler/
-  );
-});
-
-test('renders a mobiledoc with a card', (assert) => {
-  assert.expect(6);
-
-  let cardName = 'title-card';
-  let expectedPayload = {};
-  let expectedOptions = {};
-  let titleCard = {
-    name: cardName,
-    type: 'html',
-    render: ({env, payload, options}) => {
-      assert.deepEqual(payload, expectedPayload, 'correct payload');
-      assert.deepEqual(options, expectedOptions, 'correct options');
-      assert.equal(env.name, cardName, 'correct name');
-      assert.ok(!env.isInEditor, 'isInEditor correct');
-      assert.ok(!!env.onTeardown, 'has onTeardown hook');
-
-      return 'Howdy friend';
-    }
-  };
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [],      // markers
-      [        // sections
-        [10, cardName, expectedPayload]
-      ]
-    ]
-  };
-  renderer = new Renderer({cards: [titleCard], cardOptions: expectedOptions});
-  let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered, '<div><div>Howdy friend</div></div>');
-});
-
-test('renders a mobiledoc with built-in image card', (assert) => {
-  assert.expect(1);
-  let cardName = ImageCard.name;
-  let payload = { src: dataUri };
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [],      // markers
-      [        // sections
-        [10, cardName, payload]
-      ]
-    ]
-  };
-  let { result: rendered } = renderer.render(mobiledoc);
-
-  assert.equal(rendered, `<div><div><img src="${dataUri}"></div></div>`);
-});
-
-test('render mobiledoc with list section and list items', (assert) => {
-  const mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [],
-      [
-        [3, 'ul', [
-          [[[], 0, 'first item']],
-          [[[], 0, 'second item']]
-        ]]
-      ]
-    ]
-  };
-  const { result: rendered } = renderer.render(mobiledoc);
-
-  assert.equal(rendered,
-               '<div><ul><li>first item</li><li>second item</li></ul></div>');
-});
-
-test('render mobiledoc with multiple spaces into &nbsp;s to preserve whitespace', (assert) => {
+test('multiple spaces should preserve whitespace with nbsps', (assert) => {
   let space = ' ';
   let repeat = (str, count) => {
     let result = '';
@@ -328,7 +395,7 @@ test('render mobiledoc with multiple spaces into &nbsp;s to preserve whitespace'
     sections: [
       [],
       [
-        [1, 'p', [
+        [MARKUP_SECTION_TYPE, 'p', [
           [[], 0, text]
         ]]
       ]
@@ -361,4 +428,45 @@ test('throws when given an unexpected mobiledoc version', (assert) => {
   assert.throws(
     () => renderer.render(mobiledoc),
     /Unexpected Mobiledoc version.*0.2.1/);
+});
+
+test('XSS: unexpected markup and list section tag names are not renderered', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [
+        [MARKUP_SECTION_TYPE, 'script', [
+          [[], 0, 'alert("markup section XSS")']
+        ]],
+        [LIST_SECTION_TYPE, 'script', [
+          [[[], 0, 'alert("list section XSS")']]
+        ]]
+      ]
+    ]
+  };
+  let { result } = renderer.render(mobiledoc);
+  assert.ok(result.indexOf('script') === -1, 'no script tag rendered');
+});
+
+test('XSS: unexpected markup types are not rendered', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [
+        ['b'], // valid
+        ['em'], // valid
+        ['script'] // invalid
+      ],
+      [
+        [MARKUP_SECTION_TYPE, 'p', [
+          [[0], 0, 'bold text'],
+          [[1,2], 3, 'alert("markup XSS")'],
+          [[], 0, 'plain text']
+        ]]
+      ]
+    ]
+  };
+  let { result } = renderer.render(mobiledoc);
+  assert.ok(result.indexOf('script') === -1, 'no script tag rendered');
 });


### PR DESCRIPTION
fixes XSS vulnerability with untrusted mobiledocs

refs https://github.com/bustlelabs/mobiledoc-kit/issues/232