### PR TITLE
Mobiledoc 0.3.1

### DIFF
--- a/lib/renderer-factory.js
+++ b/lib/renderer-factory.js
@@ -1,5 +1,10 @@
-import Renderer_0_2, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2 } from './renderers/0-2';
-import Renderer_0_3, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from './renderers/0-3';
+import Renderer_0_2, {
+  MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2
+} from './renderers/0-2';
+import Renderer_0_3, {
+  MOBILEDOC_VERSION_0_3_0,
+  MOBILEDOC_VERSION_0_3_1
+} from './renderers/0-3';
 import RENDER_TYPE from './utils/render-type';
 
 function validateCards(cards) {
@@ -64,7 +69,8 @@ export default class RendererFactory {
       case undefined:
       case null:
         return new Renderer_0_2(mobiledoc, this.state).render();
-      case MOBILEDOC_VERSION_0_3:
+      case MOBILEDOC_VERSION_0_3_0:
+      case MOBILEDOC_VERSION_0_3_1:
         return new Renderer_0_3(mobiledoc, this.state).render();
       default:
         throw new Error(`Unexpected Mobiledoc version "${version}"`);

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -23,7 +23,9 @@ import {
   ATOM_MARKER_TYPE
 } from '../utils/marker-types';
 
-export const MOBILEDOC_VERSION = '0.3.0';
+export const MOBILEDOC_VERSION_0_3_0 = '0.3.0';
+export const MOBILEDOC_VERSION_0_3_1 = '0.3.1';
+export const MOBILEDOC_VERSION = MOBILEDOC_VERSION_0_3_0;
 
 /**
  * runtime HTML renderer
@@ -46,7 +48,7 @@ function createElementFromMarkerType([tagName, attributes]=['', []]) {
 }
 
 function validateVersion(version) {
-  if (version !== MOBILEDOC_VERSION) {
+  if (version !== MOBILEDOC_VERSION_0_3_0 && version !== MOBILEDOC_VERSION_0_3_1) {
     throw new Error(`Unexpected Mobiledoc version "${version}"`);
   }
 }

--- a/lib/utils/tag-names.js
+++ b/lib/utils/tag-names.js
@@ -5,7 +5,7 @@ import {
 import { normalizeTagName } from './dom';
 
 const MARKUP_SECTION_TAG_NAMES = [
-  'p', 'h1', 'h2', 'h3', 'blockquote', 'pull-quote'
+  'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pull-quote', 'aside'
 ].map(normalizeTagName);
 
 const LIST_SECTION_TAG_NAMES = [
@@ -13,7 +13,7 @@ const LIST_SECTION_TAG_NAMES = [
 ].map(normalizeTagName);
 
 const MARKUP_TYPES = [
-  'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's'
+  'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's', 'code'
 ].map(normalizeTagName);
 
 function contains(array, item) {

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -18,6 +18,7 @@ import {
 
 const { test, module } = QUnit;
 const MOBILEDOC_VERSION = '0.3.0';
+const MOBILEDOC_VERSION_0_3_1 = '0.3.1';
 const dataUri = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
 
 let renderer;
@@ -56,6 +57,23 @@ test('renders a mobiledoc without markups', (assert) => {
   let { result: rendered } = renderer.render(mobiledoc);
   assert.equal(rendered,
                '<div><p>hello world</p></div>');
+});
+
+test('renders a mobiledoc with aside without markups', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION_0_3_1,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [MARKUP_SECTION_TYPE, 'ASIDE', [
+        [MARKUP_MARKER_TYPE, [], 0, 'hello world']]
+      ]
+    ]
+  };
+  let { result: rendered } = renderer.render(mobiledoc);
+  assert.equal(rendered,
+               '<div><aside>hello world</aside></div>');
 });
 
 test('renders a mobiledoc with simple (no attributes) markup', (assert) => {


### PR DESCRIPTION
Upgrade the renderer to support 0.3.1. Adds `h4`, `h5`, `h6`, `aside` sections also adds markup of `code`.